### PR TITLE
Font Missing from Player And Bot Scores in Game Page #4 

### DIFF
--- a/resources/CSS/game.css
+++ b/resources/CSS/game.css
@@ -172,7 +172,7 @@ h1 {
   /* border-radius:50%; */
   transform: translate(-50%, 50%);
   border-radius: 6px;
-  font-family: sans-serif;
+  /* font-family: sans-serif; */
 }
 
 .bot-score {
@@ -186,7 +186,7 @@ h1 {
   right: 5%;
   transform: translate(-50%, 50%);
   border-radius: 6px;
-  font-family: sans-serif;
+  /* font-family: sans-serif; */
 }
 
 footer {


### PR DESCRIPTION
Solved : #4 
Font Missing from Player And Bot Scores in Game Page #4
 
Changes : 
![image](https://user-images.githubusercontent.com/96634646/158006124-5b4bd6d7-18cb-4f01-bf96-f8fd643ed586.png)
removed the font-family from scoreboard styling so that it inherit the default font from the body

Result : 
![image](https://user-images.githubusercontent.com/96634646/158006139-2f7e8acc-3fc4-456e-88bd-f967583bd814.png)
