### PR TITLE
Wrong Image Alts in Main Page and Scissor Image missing #3

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,22 +77,22 @@
       />
       <img
         src="resources/images/paper.png "
-        alt="rock"
+        alt="paper"
         class="col span-1-of-5 box"
       />
       <img
-        src="resources/images/scissor.png "
-        alt="rock"
+        src="resources/images/scissors.png "
+        alt="scissors"
         class="col span-1-of-5 box"
       />
       <img
         src="resources/images/lizard.png "
-        alt="rock"
+        alt="lizard"
         class="col span-1-of-5 box"
       />
       <img
         src="resources/images/spock.png "
-        alt="rock"
+        alt="spock"
         class="col span-1-of-5 box"
       />
     </div>


### PR DESCRIPTION
Changed alt of the images and corrected scissors image path.
![ss4](https://user-images.githubusercontent.com/96468766/158013697-e5490616-1391-4b0c-9d7e-ff4cb4ee12e9.png)